### PR TITLE
Adding IntelliCode Privacy page

### DIFF
--- a/docs/intelliCode-privacy.md
+++ b/docs/intelliCode-privacy.md
@@ -1,0 +1,37 @@
+---
+title: IntelliCode privacy
+ms.date: 08/24/2021
+ms.prod: visual-studio-family
+ms.technology: intellicode
+ms.topic: conceptual
+description: IntelliCode privacy
+author: DavidObando
+ms.author: daoabndo
+manager: jmartens
+---
+# IntelliCode privacy
+
+## Firewall and proxy settings
+For IntelliCode to gain access to the web services, network managers will need to add `*.intellicode.vsengsaas.visualstudio.com` on https/443 to an allow list. Conversely, adding it to a block list will prevent IntelliCode from working in your network.
+
+Additional information can be found at [Install and use Visual Studio and Azure Services behind a firewall or proxy server](https://docs.microsoft.com/en-us/visualstudio/install/install-and-use-visual-studio-behind-a-firewall-or-proxy-server).
+
+## Team completion models
+Certain IntelliCode features require access to the IntelliCode web services in order to obtain model files, or to submit code metadata to train new team completion models for your own code. The IntelliCode web services doesn't keep a copy of your custom model once it has been delivered to your instance of Visual Studio. If for some reason your instance of Visual Studio never collects a custom model that it sent up for training, we automatically delete it from our services 29 days after the model was produced.
+
+Additional information can be seen in the [Custom Models Data and Privacy])(custom-models#data-and-privacy) section.
+
+## Corporate controls over Team completion model training
+Team completion model training and team completion model acquisition can be disabled by corporate policy across all the machines that run Visual Studio in your organization, via registry keys.
+
+Global policy:
+  - Path: `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\VisualStudio\IntelliCode`
+  - Key: DisableRemoteAnalysis
+  - Key type:  DWORD (32-bit)
+  - A value of 1 indicates opt-out
+
+Local policy:
+  - Path: `HKEY_CURRENT_USER\SOFTWARE\Microsoft\VSCommon\16.0\IntelliCode` or `HKEY_CURRENT_USER\SOFTWARE\Microsoft\VSCommon\17.0\IntelliCode`
+  - Key: DisableRemoteAnalysis
+  - Key type:  DWORD (32-bit)
+  - A value of 1 indicates opt-out

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -18,6 +18,8 @@
   - name: Share models
     href: share-models.md
   - name: Suggestions
-    href: IntelliCode-suggestions.md
+    href: intelliCode-suggestions.md
+  - name: Privacy
+    href: intelliCode-privacy.md
 - name: IntelliCode for Visual Studio Code
   href: intellicode-visual-studio-code.md


### PR DESCRIPTION
This new privacy page is a reference for people and organizations that want to understand ways to block Visual Studio IntelliCode from working in their organization.